### PR TITLE
Fix composer installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ will not write about `Payfort` operations, what and how to use.
 
 You can install `Larafort` package to your laravel project via composer command:
 ```
-$ composer require dev-object/laravel-payfort
+$ composer require dev-object/larafort
 ```
 
 ## Configuration


### PR DESCRIPTION
Fixed composer install command since it returns no package found since Packagist name for this package is dev-object/larafort instead of dev-object/laravel-payfort